### PR TITLE
#11 [FEAT] 영양제 추가 기능 구현

### DIFF
--- a/app/src/main/java/com/prography/pilit/data/datasource/remote/pill/PillApiService.kt
+++ b/app/src/main/java/com/prography/pilit/data/datasource/remote/pill/PillApiService.kt
@@ -13,6 +13,9 @@ interface PillApiService {
     @GET("/api/v1/pill-alerts")
     suspend fun requestAlert(@Query("year") year: Int, @Query("month") month: Int, @Query("day") day: Int): AlertResponse
 
+    @POST("/api/v1/pill-alerts")
+    suspend fun requestAddAlert(@Body body:AddAlertRequest): Response<AddAlertResponse>
+
     @PUT("/api/v1/pill-alerts/{alertId}")
     suspend fun requestEditAlert(@Path("alertId") alertId: Int, @Body body:AddAlertRequest): Response<AddAlertResponse>
 

--- a/app/src/main/java/com/prography/pilit/data/repository/PillRepositoryImpl.kt
+++ b/app/src/main/java/com/prography/pilit/data/repository/PillRepositoryImpl.kt
@@ -19,6 +19,9 @@ class PillRepositoryImpl @Inject constructor(
     override suspend fun postTakingLogs(request: EatRequest): Boolean =
         pillApiService.postTakingLogs(request).result
 
+    override suspend fun requestAddAlert(body:AddAlertRequest): Response<AddAlertResponse> =
+        pillApiService.requestAddAlert(body)
+
     override suspend fun requestEditAlert(alertId: Int, body:AddAlertRequest): Response<AddAlertResponse> =
         pillApiService.requestEditAlert(alertId, body)
 

--- a/app/src/main/java/com/prography/pilit/domain/repository/PillRepository.kt
+++ b/app/src/main/java/com/prography/pilit/domain/repository/PillRepository.kt
@@ -12,6 +12,8 @@ interface PillRepository {
 
     suspend fun postTakingLogs(request: EatRequest): Boolean
 
+    suspend fun requestAddAlert(body:AddAlertRequest): Response<AddAlertResponse>
+
     suspend fun requestEditAlert(alertId: Int, body: AddAlertRequest): Response<AddAlertResponse>
 
     suspend fun requestDeleteAlert(alertId: Int): Response<DeleteResponse>

--- a/app/src/main/java/com/prography/pilit/domain/usecase/RequestAddAlertUseCase.kt
+++ b/app/src/main/java/com/prography/pilit/domain/usecase/RequestAddAlertUseCase.kt
@@ -1,0 +1,13 @@
+package com.prography.pilit.domain.usecase
+
+import com.prography.pilit.data.datasource.remote.pill.AddAlertRequest
+import com.prography.pilit.domain.repository.PillRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RequestAddAlertUseCase @Inject constructor(
+    private val pillRepository: PillRepository
+){
+    suspend operator fun invoke(body: AddAlertRequest) = pillRepository.requestAddAlert(body)
+}

--- a/app/src/main/java/com/prography/pilit/presentation/activity/EditPillActivity.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/activity/EditPillActivity.kt
@@ -78,7 +78,7 @@ class EditPillActivity : AppCompatActivity() {
 
     fun setTimeSettingButtonClickListener(){
         binding.ivEditPillIntakeTimeSetting.setOnClickListener {
-            val originTime = binding.tvEditPillIntakeTimeAlarmTime.text.split(":")
+            val originTime = alertTime24.split(":")
             TimePickerDialog(this, { view, hour, minute ->
                 val cal = Calendar.getInstance()
                 cal.set(Calendar.HOUR_OF_DAY, hour)
@@ -99,7 +99,7 @@ class EditPillActivity : AppCompatActivity() {
             val body = AddAlertRequest(alertTime, alertWeek, isPush, pillName)
             viewModel.requestEditAlert(alertId = pillData.alertId, body = body)
             viewModel.editAlertSuccess.observe(this){
-                this.finish()
+                if(it) this.finish()
             }
         }
     }

--- a/app/src/main/java/com/prography/pilit/presentation/fragment/AddPillFragment.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/fragment/AddPillFragment.kt
@@ -1,18 +1,31 @@
 package com.prography.pilit.presentation.fragment
 
+import android.app.TimePickerDialog
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.prography.pilit.R
+import com.prography.pilit.data.datasource.remote.pill.AddAlertRequest
 import com.prography.pilit.databinding.FragmentAddPillBinding
+import com.prography.pilit.domain.model.Week
+import com.prography.pilit.presentation.activity.MainActivity
+import com.prography.pilit.presentation.viewmodel.AddPillViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import java.text.SimpleDateFormat
+import java.util.*
 
 @AndroidEntryPoint
 class AddPillFragment : Fragment() {
 
     private var _binding: FragmentAddPillBinding? = null
     private val binding get() = _binding!!
+    private val viewModel by viewModels<AddPillViewModel>()
+    private var alertTime24 = "08:00"
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,8 +35,91 @@ class AddPillFragment : Fragment() {
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setCompleteButtonActivation()
+        setCompleteButtonClickListener()
+        setTimeSettingButtonClickListener()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         _binding = null
+    }
+
+    fun initAddPillView(){
+        binding.etAddPillMedicineName.text = Editable.Factory.getInstance().newEditable("")
+        alertTime24 = "08:00"
+        binding.tvAddPillIntakeTimeAlarmAmPm.text = getString(R.string.add_pill_default_alarm_am_pm)
+        binding.tvAddPillIntakeTimeAlarmTime.text = getString(R.string.add_pill_default_alarm_time)
+        binding.cbAddPillRepetitionOptionSun.isChecked = true
+        binding.cbAddPillRepetitionOptionMon.isChecked = true
+        binding.cbAddPillRepetitionOptionTue.isChecked = true
+        binding.cbAddPillRepetitionOptionWed.isChecked = true
+        binding.cbAddPillRepetitionOptionThu.isChecked = true
+        binding.cbAddPillRepetitionOptionFri.isChecked = true
+        binding.cbAddPillRepetitionOptionSat.isChecked = true
+        binding.switchAddPillPush.isChecked = true
+    }
+
+    fun setCompleteButtonActivation(){
+        binding.etAddPillMedicineName.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
+            override fun afterTextChanged(s: Editable?) {
+                when {
+                    s.toString().trim().isEmpty() -> {
+                        binding.btnAddPillComplete.isEnabled = false
+                    }
+                    else -> {
+                        binding.btnAddPillComplete.isEnabled = true
+                    }
+                }
+            }
+        })
+    }
+
+    fun getCheckedDay():List<Week>{
+        val alertWeek:MutableList<Week> = mutableListOf()
+        if(binding.cbAddPillRepetitionOptionSun.isChecked) alertWeek.add(Week.Sun)
+        if(binding.cbAddPillRepetitionOptionMon.isChecked) alertWeek.add(Week.Mon)
+        if(binding.cbAddPillRepetitionOptionTue.isChecked) alertWeek.add(Week.Tue)
+        if(binding.cbAddPillRepetitionOptionWed.isChecked) alertWeek.add(Week.Wed)
+        if(binding.cbAddPillRepetitionOptionThu.isChecked) alertWeek.add(Week.Thu)
+        if(binding.cbAddPillRepetitionOptionFri.isChecked) alertWeek.add(Week.Fri)
+        if(binding.cbAddPillRepetitionOptionSat.isChecked) alertWeek.add(Week.Sat)
+        return alertWeek.toList()
+    }
+
+    fun setTimeSettingButtonClickListener(){
+        binding.ivAddPillIntakeTimeSetting.setOnClickListener {
+            val originTime = alertTime24.split(":")
+            TimePickerDialog(requireActivity(), { view, hour, minute ->
+                val cal = Calendar.getInstance()
+                cal.set(Calendar.HOUR_OF_DAY, hour)
+                cal.set(Calendar.MINUTE, minute)
+                alertTime24 = SimpleDateFormat("HH:mm").format(cal.time)
+                binding.tvAddPillIntakeTimeAlarmAmPm.text = if(hour < 12) "오전" else "오후"
+                binding.tvAddPillIntakeTimeAlarmTime.text = SimpleDateFormat("hh:mm").format(cal.time)
+            }, originTime[0].toInt(), originTime[1].toInt(), false).show()
+        }
+    }
+
+    fun setCompleteButtonClickListener(){
+        binding.btnAddPillComplete.setOnClickListener {
+            var alertTime = alertTime24
+            var alertWeek = getCheckedDay()
+            val isPush = binding.switchAddPillPush.isChecked
+            val pillName = binding.etAddPillMedicineName.text.toString()
+            val body = AddAlertRequest(alertTime, alertWeek, isPush, pillName)
+            viewModel.requestAddAlert(body = body)
+            viewModel.addAlertSuccess.observe(viewLifecycleOwner){
+                if(it) {
+                    initAddPillView()
+                    (requireActivity() as MainActivity).moveToFragment(0)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/prography/pilit/presentation/fragment/PillListFragment.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/fragment/PillListFragment.kt
@@ -100,7 +100,7 @@ class PillListFragment : Fragment() {
             1 -> { // 삭제
                 viewModel.requestDeleteAlert(alertId = pillData.alertId)
                 viewModel.deleteAlertSuccess.observe(viewLifecycleOwner){
-                    setAlertData()
+                    if(it) setAlertData()
                 }
             }
         }

--- a/app/src/main/java/com/prography/pilit/presentation/viewmodel/AddPillViewModel.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/viewmodel/AddPillViewModel.kt
@@ -1,9 +1,28 @@
 package com.prography.pilit.presentation.viewmodel
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.prography.pilit.data.datasource.remote.pill.AddAlertRequest
+import com.prography.pilit.domain.usecase.RequestAddAlertUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AddPillViewModel @Inject constructor() : ViewModel() {
+class AddPillViewModel @Inject constructor(
+    private val requestAddAlertUseCase: RequestAddAlertUseCase
+) : ViewModel() {
+
+    val addAlertSuccess: MutableLiveData<Boolean> = MutableLiveData()
+
+    fun requestAddAlert(body: AddAlertRequest) = viewModelScope.launch {
+        val response = requestAddAlertUseCase(body = body)
+        if(response.isSuccessful){
+            addAlertSuccess.postValue(true)
+        }
+        else{
+            addAlertSuccess.postValue(false)
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_add_pill.xml
+++ b/app/src/main/res/layout/fragment_add_pill.xml
@@ -47,7 +47,7 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/et_add_pill_medicine_name"
+                android:id="@+id/til_add_pill_medicine_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 style="@style/BorderEditText"
@@ -57,6 +57,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" >
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_add_pill_medicine_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     style="@style/TextInputEditTextStyle"
@@ -75,7 +76,7 @@
                 android:visibility="gone"
                 android:layout_marginTop="12dp"
                 android:layout_marginHorizontal="20dp"
-                app:layout_constraintTop_toBottomOf="@id/et_add_pill_medicine_name"
+                app:layout_constraintTop_toBottomOf="@id/til_add_pill_medicine_name"
                 app:layout_constraintBottom_toTopOf="@id/tv_add_pill_intake_time_subheading" />
 
             <TextView
@@ -91,17 +92,29 @@
                 app:layout_constraintTop_toBottomOf="@id/tv_add_pill_medicine_information"
                 app:layout_constraintStart_toStartOf="parent" />
 
-            <TextView
-                android:id="@+id/tv_add_pill_intake_time_alarm_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="14dp"
-                android:text="@string/add_pill_default_alarm_time"
-                android:textColor="@color/black"
-                android:textSize="16dp"
-                app:layout_constraintTop_toBottomOf="@id/tv_add_pill_intake_time_subheading"
-                app:layout_constraintStart_toStartOf="parent" />
+        <TextView
+            android:id="@+id/tv_add_pill_intake_time_alarm_am_pm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="14dp"
+            android:text="@string/add_pill_default_alarm_am_pm"
+            android:textColor="@color/black"
+            android:textSize="16dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_add_pill_intake_time_subheading"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_add_pill_intake_time_alarm_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:layout_marginStart="2dp"
+            android:text="@string/add_pill_default_alarm_time"
+            android:textColor="@color/black"
+            android:textSize="16dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_add_pill_intake_time_alarm_am_pm"
+            app:layout_constraintStart_toEndOf="@id/tv_add_pill_intake_time_alarm_am_pm" />
 
             <ImageView
                 android:id="@+id/iv_add_pill_intake_time_setting"
@@ -290,6 +303,7 @@
                 app:layout_constraintEnd_toEndOf="parent" />
 
             <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_add_pill_complete"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="20dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,8 @@
     <string name="add_pill_medicine_name_subheading">약 추가</string>
     <string name="add_pill_medicine_name_hint">약 이름을 알려주세요</string>
     <string name="add_pill_intake_time_subheading">섭취 시간</string>
-    <string name="add_pill_default_alarm_time">오전 8:00</string>
+    <string name="add_pill_default_alarm_am_pm">오전</string>
+    <string name="add_pill_default_alarm_time">8:00</string>
     <string name="add_pill_repetition_subheading">반복</string>
     <string name="add_pill_repetition_option_sun">일</string>
     <string name="add_pill_repetition_option_mon">월</string>


### PR DESCRIPTION
## 작업 내용
+ 영양제 추가 페이지의 기능을 구현합니다.
+ 모든 요일 알림을 기본으로 설정합니다.
+ 기본 섭취 시간을 오전 8시로 설정합니다.
+ 영양제 추가 완료 시 홈 화면으로 이동합니다.
  + 완료 시 영양제 추가 화면을 초기화 합니다. 