### PR TITLE
[FIX] 캘린더 오류 수정 #28

### DIFF
--- a/app/src/main/java/com/prography/pilit/presentation/adapter/CalendarRecordAdapter.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/adapter/CalendarRecordAdapter.kt
@@ -10,9 +10,7 @@ import com.prography.pilit.databinding.ItemCalendarRecordBinding
 import com.prography.pilit.domain.model.Pill
 import com.prography.pilit.extension.toStringWithComma
 
-class CalendarRecordAdapter(
-    private val onPillClicked: (alertId: Int) -> Unit
-) : ListAdapter<Pill, CalendarRecordAdapter.ViewHolder>(pillComparator) {
+class CalendarRecordAdapter() : ListAdapter<Pill, CalendarRecordAdapter.ViewHolder>(pillComparator) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType:Int): ViewHolder =
         ViewHolder(
@@ -20,8 +18,7 @@ class CalendarRecordAdapter(
                 LayoutInflater.from(parent.context),
                 parent,
                 false
-            ),
-            onPillClicked
+            )
         )
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -30,15 +27,11 @@ class CalendarRecordAdapter(
 
     inner class ViewHolder(
         private val binding: ItemCalendarRecordBinding,
-        private val onPillClicked: (alertId: Int) -> Unit
     ): RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Pill) {
             binding.pill = item
             binding.alertTime = item.alertTime.toStringWithComma()
-            binding.btnEat.setOnClickListener {
-                binding.pill = item.copy(isEaten = binding.pill!!.isEaten.not())
-                onPillClicked(item.alertId)
-            }
+            binding.alertTime = item.alertTime.toStringWithComma()
         }
     }
 

--- a/app/src/main/java/com/prography/pilit/presentation/fragment/CalendarFragment.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/fragment/CalendarFragment.kt
@@ -143,7 +143,7 @@ class CalendarFragment : Fragment() {
                     }
 
                     if (takeLog != null) {
-                        if (takeLog.pillState == 0) {
+                        if (takeLog.pillState == 1) {
                             textView.setBackgroundResource(R.drawable.bg_pill_part_eaten)
                             textView.setTextColorRes(R.color.black)
                         } else {

--- a/app/src/main/java/com/prography/pilit/presentation/fragment/CalendarFragment.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/fragment/CalendarFragment.kt
@@ -47,10 +47,10 @@ class CalendarFragment : Fragment() {
     private val binding get() = _binding ?: throw IllegalArgumentException("Must be initialized.")
     private val viewModel by viewModels<CalendarViewModel>()
 
-    private var selectedDate: LocalDate? = LocalDate.now()
+    private var selectedDate: LocalDate? = null
 
     private val adapter by lazy {
-        CalendarRecordAdapter(this::eatPill)
+        CalendarRecordAdapter()
     }
 
     private val logList: MutableList<TakeLog> = mutableListOf()
@@ -107,8 +107,6 @@ class CalendarFragment : Fragment() {
             val legendLayout = ItemCalendarHeaderBinding.bind(view).legendLayout.root
         }
 
-
-
         val currentMonth = YearMonth.now()
         val firstMonth = currentMonth.minusMonths(10)
         val lastMonth = currentMonth.plusMonths(10)
@@ -116,8 +114,6 @@ class CalendarFragment : Fragment() {
         binding.calendarView.setup(firstMonth, lastMonth, firstDayOfWeek)
         binding.calendarView.scrollToMonth(currentMonth)
         viewModel.getMonthlyPillList(currentMonth.year, currentMonth.month.value)
-
-        //viewModel.getAlertList()
 
         binding.calendarView.dayBinder = object : DayBinder<DayViewContainer> {
             // Called only when a new container is needed.
@@ -131,10 +127,8 @@ class CalendarFragment : Fragment() {
                 container.day = day
 
                 if (day.owner == DayOwner.THIS_MONTH) {
-
                     textView.makeVisible()
                     textView.text = day.date.dayOfMonth.toString()
-
                     if (day.date == selectedDate) {
                         dotView.makeVisible()
                     } else {
@@ -147,6 +141,7 @@ class CalendarFragment : Fragment() {
                             DateTimeFormatter.ISO_DATE
                         ) == day.date
                     }
+
                     if (takeLog != null) {
                         if (takeLog.pillState == 0) {
                             textView.setBackgroundResource(R.drawable.bg_pill_part_eaten)
@@ -165,7 +160,6 @@ class CalendarFragment : Fragment() {
                 }
             }
         }
-
 
         viewModel.monthlyPillListData.observe(viewLifecycleOwner) {
             logList.clear()
@@ -201,10 +195,9 @@ class CalendarFragment : Fragment() {
                 selectedDate = null
                 binding.calendarView.notifyDateChanged(it)
                 updateAdapterForDate(null)
+                selectDate(month.yearMonth.atDay(1))
             }
-            selectDate(month.yearMonth.atDay(1))
         }
-
 
         binding.ivPreviousMonth.setOnClickListener {
             binding.calendarView.findFirstVisibleMonth()?.let {
@@ -212,15 +205,11 @@ class CalendarFragment : Fragment() {
             }
         }
 
-
-        if (savedInstanceState == null) {
-            binding.calendarView.post {
-                selectDate(LocalDate.now())
-            }
+        binding.calendarView.post {
+            selectDate(LocalDate.now())
         }
 
         binding.layoutEmpty.btnAddAlert.setOnClickListener {
-
             (requireActivity() as MainActivity).moveToFragment(R.id.addPillFragment)
         }
 
@@ -234,10 +223,7 @@ class CalendarFragment : Fragment() {
                 adapter.submitList(it)
             }
         }
-
-
     }
-
 
     private fun initRecyclerView() {
         binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
@@ -257,16 +243,7 @@ class CalendarFragment : Fragment() {
             oldDate?.let { binding.calendarView.notifyDateChanged(it) }
             binding.calendarView.notifyDateChanged(date)
             updateAdapterForDate(date)
-            binding.tvRecordDate.text = String.format(
-                getString(R.string.calendar_record_date),
-                date.monthValue,
-                date.dayOfMonth
-            )
         }
-    }
-
-    private fun eatPill(alertId: Int) {
-        viewModel.postTakingLogs(alertId)
     }
 
     private fun updateAdapterForDate(date: LocalDate?) {
@@ -276,6 +253,10 @@ class CalendarFragment : Fragment() {
             date?.dayOfMonth ?: LocalDate.now().dayOfMonth
         )
         adapter.notifyItemRangeRemoved(0, adapter.itemCount)
+        binding.tvRecordDate.text = String.format(
+            getString(R.string.calendar_record_date),
+            date?.monthValue ?: LocalDate.now().monthValue,
+            date?.dayOfMonth ?: LocalDate.now().dayOfMonth
+        )
     }
 }
-

--- a/app/src/main/res/layout/item_calendar_record.xml
+++ b/app/src/main/res/layout/item_calendar_record.xml
@@ -40,18 +40,19 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageButton
+        <ImageView
             android:id="@+id/btn_eat"
             android:layout_width="50dp"
             android:layout_height="50dp"
-            android:src="@{pill.eaten ? @drawable/ic_btn_pill_normal_50 : @drawable/ic_btn_pill_press_50}"
+            android:src="@{pill.eaten ? @drawable/ic_btn_pill_press_50 : @drawable/ic_btn_pill_normal_50}"
             android:background="@color/transparent"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
             android:contentDescription="@string/description_record_eat"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 다른 페이지에서 캘린더 페이지로 돌아왔을 때 선택 날짜가 1일로 바뀌는 오류 수정
- 달력에 선택된 날짜와 리스트에 출력된 날짜가 일치하지 않는 오류 수정
- 영양제 섭취 버튼 비활성화