### PR TITLE
#31 [FIX] 약 추가 화면 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/prography/pilit/presentation/activity/MainActivity.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/activity/MainActivity.kt
@@ -1,7 +1,8 @@
 package com.prography.pilit.presentation.activity
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.navigation.ui.setupWithNavController
@@ -24,6 +25,14 @@ class MainActivity : AppCompatActivity() {
         navController = Navigation.findNavController(this, R.id.nav_host)
         mainBinding.bottomNavigation.setupWithNavController(navController)
         mainBinding.bottomNavigation.itemIconTintList = null
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            mainBinding.bottomNavigation.visibility = when (destination.id) {
+                R.id.pillListFragment -> View.VISIBLE
+                R.id.addPillFragment -> View.VISIBLE
+                R.id.calendarFragment -> View.VISIBLE
+                else -> View.GONE
+            }
+        }
     }
 
     fun moveToFragment(fragmentIndex: Int) {

--- a/app/src/main/java/com/prography/pilit/presentation/adapter/IntakeTimeListAdapter.kt
+++ b/app/src/main/java/com/prography/pilit/presentation/adapter/IntakeTimeListAdapter.kt
@@ -36,7 +36,7 @@ class IntakeTimeListAdapter(
             val alertTime12 = SimpleDateFormat("hh:mm").format(alertTime24)
             binding.amPm = am_pm
             binding.intakeTime = alertTime12
-            binding.ivAddPillIntakeTimeSetting.setOnClickListener {
+            binding.root.setOnClickListener {
                 onTimeClicked(position)
             }
         }

--- a/app/src/main/res/layout/fragment_add_pill.xml
+++ b/app/src/main/res/layout/fragment_add_pill.xml
@@ -157,6 +157,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginHorizontal="20dp"
             android:nestedScrollingEnabled="false"
+            android:overScrollMode="never"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toBottomOf="@id/tv_add_pill_intake_time_subheading"
             app:layout_constraintStart_toStartOf="parent"
@@ -176,133 +177,123 @@
             app:layout_constraintTop_toBottomOf="@id/rv_add_pill_intake_time"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:id="@+id/cl_add_pill_repetition_week"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="14dp"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal"
             app:layout_constraintTop_toBottomOf="@id/tv_add_pill_repetition_subheading"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" >
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_sun"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_sun"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_mon"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_mon"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cb_add_pill_repetition_option_sun"
-                app:layout_constraintEnd_toStartOf="@+id/cb_add_pill_repetition_option_tue" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_tue"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_tue"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cb_add_pill_repetition_option_mon"
-                app:layout_constraintEnd_toStartOf="@+id/cb_add_pill_repetition_option_wed" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_wed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_wed"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cb_add_pill_repetition_option_tue"
-                app:layout_constraintEnd_toStartOf="@+id/cb_add_pill_repetition_option_thu" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_thu"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_thu"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cb_add_pill_repetition_option_wed"
-                app:layout_constraintEnd_toStartOf="@+id/cb_add_pill_repetition_option_fri" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_fri"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_fri"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cb_add_pill_repetition_option_thu"
-                app:layout_constraintEnd_toStartOf="@+id/cb_add_pill_repetition_option_sat" />
+                android:textColor="@drawable/selector_day_checkbox_text" />
 
             <CheckBox
                 android:id="@+id/cb_add_pill_repetition_option_sat"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/selector_day_checkbox"
                 android:button="@android:color/transparent"
                 android:checked="true"
                 android:gravity="center"
+                android:layout_weight="1"
+                android:layout_marginHorizontal="4dp"
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="10dp"
                 android:text="@string/add_pill_repetition_option_sat"
-                android:textColor="@drawable/selector_day_checkbox_text"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                android:textColor="@drawable/selector_day_checkbox_text" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/tv_add_pill_push_subheading"

--- a/app/src/main/res/layout/fragment_edit_pill.xml
+++ b/app/src/main/res/layout/fragment_edit_pill.xml
@@ -178,6 +178,7 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginHorizontal="20dp"
                 android:nestedScrollingEnabled="false"
+                android:overScrollMode="never"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/tv_edit_pill_intake_time_subheading"
                 app:layout_constraintStart_toStartOf="parent"
@@ -197,133 +198,123 @@
                 app:layout_constraintTop_toBottomOf="@id/rv_edit_pill_intake_time"
                 app:layout_constraintStart_toStartOf="parent" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:id="@+id/cl_edit_pill_repetition_week"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="20dp"
                 android:layout_marginTop="14dp"
+                android:orientation="horizontal"
+                android:gravity="center_horizontal"
                 app:layout_constraintTop_toBottomOf="@id/tv_edit_pill_repetition_subheading"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" >
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_sun"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Sun)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_sun"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_mon"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Mon)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_mon"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/cb_edit_pill_repetition_option_sun"
-                    app:layout_constraintEnd_toStartOf="@+id/cb_edit_pill_repetition_option_tue" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_tue"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Tue)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_tue"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/cb_edit_pill_repetition_option_mon"
-                    app:layout_constraintEnd_toStartOf="@+id/cb_edit_pill_repetition_option_wed" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_wed"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Wed)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_wed"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/cb_edit_pill_repetition_option_tue"
-                    app:layout_constraintEnd_toStartOf="@+id/cb_edit_pill_repetition_option_thu" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_thu"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Thu)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_thu"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/cb_edit_pill_repetition_option_wed"
-                    app:layout_constraintEnd_toStartOf="@+id/cb_edit_pill_repetition_option_fri" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_fri"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Fri)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_fri"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/cb_edit_pill_repetition_option_thu"
-                    app:layout_constraintEnd_toStartOf="@+id/cb_edit_pill_repetition_option_sat" />
+                    android:textColor="@drawable/selector_day_checkbox_text" />
 
                 <CheckBox
                     android:id="@+id/cb_edit_pill_repetition_option_sat"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selector_day_checkbox"
                     android:button="@android:color/transparent"
                     android:checked="@{pill.alertWeek.contains(Week.Sat)}"
                     android:gravity="center"
+                    android:layout_weight="1"
+                    android:layout_marginHorizontal="4dp"
                     android:paddingHorizontal="14dp"
                     android:paddingVertical="10dp"
                     android:text="@string/add_pill_repetition_option_sat"
-                    android:textColor="@drawable/selector_day_checkbox_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:textColor="@drawable/selector_day_checkbox_text" />
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/tv_edit_pill_push_subheading"

--- a/app/src/main/res/layout/item_intake_time.xml
+++ b/app/src/main/res/layout/item_intake_time.xml
@@ -14,8 +14,8 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:layout_marginBottom="6dp">
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp">
 
         <TextView
             android:id="@+id/tv_add_pill_intake_time_alarm_am_pm"


### PR DESCRIPTION
+ 기기 화면 크기에 따라 약 추가 화면의 반복 레이아웃의 버튼이 겹치는 문제 수정
+ 약 추가 화면의 섭취시간 터치 영역 확대 
+ 약 수정 시 bottom navigation bar 안보이도록 수정

resolved : #31